### PR TITLE
Add onStartResizing and onStopResizing callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Sets the resize behavior of the panel.  Fixed cannot be resized. Defaults to "st
 An array of positions to snap to per panel <br/><br/>
 - `onUpdate: function()`<br/>
 Callback to recieve state updates from PanelGroup to allow controlling state externally.  Returns an array of panelWidths <br/><br/>
+- `onStartResizing: function()`<br/>
+Callback called when the mouse button is pressed on the border between any panels <br/><br/>
+- `onStopResizing: function()`<br/>
+Callback called when the mouse button is released from the border between any panels <br/><br/>
 
 
 ## Contribute

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -97,6 +97,18 @@ var PanelGroup = React.createClass({
     }
   },
 
+  onStartResizing: function(panels) {
+    if (this.props.onStartResizing) {
+      this.props.onStartResizing()
+    }
+  },
+
+  onStopResizing: function(panels) {
+    if (this.props.onStopResizing) {
+      this.props.onStopResizing()
+    }
+  },
+
   // For styling, track which direction to apply sizing to
   getSizeDirection: function(caps) {
     if (caps)
@@ -168,7 +180,17 @@ var PanelGroup = React.createClass({
 
       // add a handle between panels
       if (i < initialChildren.length-1) {
-        newChildren.push(<Divider borderColor={this.props.borderColor} key={"divider"+i} panelID={i} handleResize={this.handleResize} dividerWidth={this.props.spacing} direction={this.props.direction} showHandles={this.props.showHandles}/>);
+        newChildren.push(<Divider
+          borderColor={this.props.borderColor}
+          key={"divider"+i}
+          panelID={i}
+          handleResize={this.handleResize}
+          dividerWidth={this.props.spacing}
+          direction={this.props.direction}
+          showHandles={this.props.showHandles}
+          onStartResizing={this.onStartResizing}
+          onStopResizing={this.onStopResizing}
+        />);
       }
     }
 
@@ -429,9 +451,11 @@ var Divider = React.createClass({
     if (this.state.dragging && !state.dragging) {
       document.addEventListener('mousemove', this.onMouseMove)
       document.addEventListener('mouseup', this.onMouseUp)
+      this.props.onStartResizing()
     } else if (!this.state.dragging && state.dragging) {
       document.removeEventListener('mousemove', this.onMouseMove)
       document.removeEventListener('mouseup', this.onMouseUp)
+      this.props.onStopResizing()
     }
   },
 

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -20,23 +20,23 @@ var PanelGroup = React.createClass({
 
   // reload panel configuration if props update
   componentWillReceiveProps: function(nextProps) {
-
+    var currentPanels = this.props.panelWidths
     var nextPanels = nextProps.panelWidths;
 
     // Only update from props if we're supplying the props in the first place
     if (nextPanels.length) {
 
       // if the panel array is a different size we know to update
-      if (this.state.panels.length !== nextPanels.length) {
+      if (currentPanels.length !== nextPanels.length) {
         this.setState(this.loadPanels(nextProps));
       }
       // otherwise we need to iterate to spot any difference
       else {
         for (var i=0; i<nextPanels.length; i++) {
           if (
-            this.state.panels[i].size !== nextPanels[i].size ||
-            this.state.panels[i].minSize !== nextPanels[i].minSize ||
-            this.state.panels[i].resize !== nextPanels[i].resize
+            currentPanels[i].size !== nextPanels[i].size ||
+            currentPanels[i].minSize !== nextPanels[i].minSize ||
+            currentPanels[i].resize !== nextPanels[i].resize
           ) {
             this.setState(this.loadPanels(nextProps));
             break;


### PR DESCRIPTION
I have an app, where one of the resizable panes is iframe. Problem is, iframe intercepts all mouse events which happen over it. I solved this problem by adding a div with `position: absolute` and `z-index` bigger than iframe's so it covers the iframe.

But I still wanted iframe to be intractable, so I had to detect when resizing event happens and render the div only then. I had to add `onStartResizing` and `onStopResizing` props to PanelGroup component for this purpose. Maybe you will also find them useful