### PR TITLE
Use correct resize cursors

### DIFF
--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -535,7 +535,7 @@ var Divider = React.createClass({
         left:   this.props.direction === "row"    ? this.getHandleOffset() : 0,
         top:    this.props.direction === "column" ? this.getHandleOffset() : 0,
         backgroundColor: this.props.showHandles? "rgba(0,128,255,0.25)" : "auto",
-        cursor: this.props.direction === "row" ? "ew-resize" : "ns-resize",
+        cursor: this.props.direction === "row" ? "col-resize" : "row-resize",
         zIndex: 100,
       }
     }


### PR DESCRIPTION
Use these cursors:
![col-resize](https://developer.mozilla.org/@api/deki/files/3435/=col-resize.gif)
![row-resize](https://developer.mozilla.org/@api/deki/files/3451/=row-resize.gif)
instead of these:
![ew-resize](https://developer.mozilla.org/files/3806/3-resize.gif)
![ns-resize](https://developer.mozilla.org/files/3808/6-resize.gif)