### PR TITLE
Max Width & Callback Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,14 +108,13 @@ Initial panel size. If panelWidth.resize is "fixed" or "dynamic" the size will b
 - `panelWidth.minSize: number`<br/>
 minimum size of panel in pixels.  Defaults to 48 <br/><br/>
 - `panelWidth.maxSize: number`<br/>
-minimum size of panel in pixels.  Defaults to 0 (No Max Width) <br/><br/>
+maximum size of panel in pixels.  Defaults to 0 (No Max Width) <br/><br/>
 - `panelWidth.resize: [ "fixed" | "dynamic" | "stretch" ]`<br/>
 Sets the resize behavior of the panel.  Fixed cannot be resized. Defaults to "stretch" <br/><br/>
 - `panelWidth.snap: [snapPoint, ...]`<br/>
 An array of positions to snap to per panel <br/><br/>
 - `onUpdate: function(panels, isComplete)`<br/>
-Callback to recieve state updates from PanelGroup to allow controlling state externally.  Returns an array of panelWidths <br/><br/>
-
+Callback to recieve state updates from PanelGroup to allow controlling state externally.  Returns an array of panelWidths: `panels`, and a boolean value indicating if the PanelGroup resize is complete: `isComplete`. This second argument can be useful to avoid conflicts between external and internal state while resizing. <br/><br/>
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -107,11 +107,13 @@ An array of panelWidth objects to initialize each panel with.  If a property is 
 Initial panel size. If panelWidth.resize is "fixed" or "dynamic" the size will be pixel units.  If panelWidth.resize is "stretch" then it is treated as a relative weight: Defaults to 256<br/><br/>
 - `panelWidth.minSize: number`<br/>
 minimum size of panel in pixels.  Defaults to 48 <br/><br/>
+- `panelWidth.maxSize: number`<br/>
+minimum size of panel in pixels.  Defaults to 0 (No Max Width) <br/><br/>
 - `panelWidth.resize: [ "fixed" | "dynamic" | "stretch" ]`<br/>
 Sets the resize behavior of the panel.  Fixed cannot be resized. Defaults to "stretch" <br/><br/>
 - `panelWidth.snap: [snapPoint, ...]`<br/>
 An array of positions to snap to per panel <br/><br/>
-- `onUpdate: function()`<br/>
+- `onUpdate: function(panels, isComplete)`<br/>
 Callback to recieve state updates from PanelGroup to allow controlling state externally.  Returns an array of panelWidths <br/><br/>
 
 

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -1,0 +1,159 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+
+
+class Divider extends React.Component {
+
+    constructor () {
+      super(...arguments);
+  
+      this.state = {
+        dragging: false,
+        initPos: {x:null,y:null},
+      };
+    }
+  
+    // Add/remove event listeners based on drag state
+    componentDidUpdate (props, state) {
+      if (this.state.dragging && !state.dragging) {
+        document.addEventListener('mousemove', this.onMouseMove)
+        document.addEventListener('mouseup', this.onMouseUp)
+      } else if (!this.state.dragging && state.dragging) {
+        document.removeEventListener('mousemove', this.onMouseMove)
+        document.removeEventListener('mouseup', this.onMouseUp)
+      }
+    }
+  
+    // Start drag state and set initial position
+    onMouseDown = (e) => {
+  
+      // only left mouse button
+      if (e.button !== 0) return
+  
+      this.setState({
+        dragging: true,
+        initPos: {
+          x: e.pageX,
+          y: e.pageY
+        },
+      })
+  
+      e.stopPropagation()
+      e.preventDefault()
+    };
+  
+    // End drag state
+    onMouseUp = (e) => {
+      this.setState({dragging: false})
+      e.stopPropagation()
+      e.preventDefault()
+  
+      return this.onResizeComplete(this.props.panelID)
+    };
+  
+    // Call resize handler if we're dragging
+    onMouseMove = (e) => {
+      if (!this.state.dragging) return;
+  
+      let initDelta = {
+        x: e.pageX - this.state.initPos.x,
+        y: e.pageY - this.state.initPos.y
+      }
+  
+      let flowMask = {
+        x: (this.props.direction === "row"    ? 1 : 0),
+        y: (this.props.direction === "column" ? 1 : 0)
+      }
+  
+      let flowDelta = (initDelta.x * flowMask.x) + (initDelta.y * flowMask.y);
+  
+      // Resize the panels
+      var resultDelta = this.handleResize(
+        this.props.panelID,
+        initDelta
+      );
+  
+      // if the divider moved, reset the initPos
+      if (resultDelta + flowDelta !== 0) {
+  
+        // Did we move the expected amount? (snapping will result in a larger delta)
+        let expectedDelta = (resultDelta === flowDelta);
+  
+        this.setState({
+          initPos: {
+            // if we moved more than expected, add the difference to the Position
+            x: e.pageX + (expectedDelta? 0 : resultDelta * flowMask.x),
+            y: e.pageY + (expectedDelta? 0 : resultDelta * flowMask.y)
+          },
+        })
+      }
+  
+      e.stopPropagation()
+      e.preventDefault()
+    };
+  
+    // Handle resizing
+    handleResize =(i, delta) => {
+      return this.props.handleResize(i, delta);
+    };
+
+    onResizeComplete = (i) => {
+        return this.props.onResizeComplete(i);
+    }
+  
+    // Utility functions for handle size provided how much bleed
+    // we want outside of the actual divider div
+    getHandleWidth = () => {
+      return (this.props.dividerWidth + (this.props.handleBleed * 2));
+    };
+    getHandleOffset = () => {
+      return (this.props.dividerWidth/2) - (this.getHandleWidth()/2);
+    };
+  
+    // Render component
+    render () {
+      var style = {
+        divider: {
+          width:    this.props.direction === "row" ? this.props.dividerWidth : "auto",
+          minWidth: this.props.direction === "row" ? this.props.dividerWidth : "auto",
+          maxWidth: this.props.direction === "row" ? this.props.dividerWidth : "auto",
+          height:    this.props.direction === "column" ? this.props.dividerWidth : "auto",
+          minHeight: this.props.direction === "column" ? this.props.dividerWidth : "auto",
+          maxHeight: this.props.direction === "column" ? this.props.dividerWidth : "auto",
+          flexGrow: 0,
+          position: "relative",
+        },
+        handle: {
+          position: "absolute",
+          width:  this.props.direction === "row"    ? this.getHandleWidth() : "100%",
+          height: this.props.direction === "column" ? this.getHandleWidth() : "100%",
+          left:   this.props.direction === "row"    ? this.getHandleOffset() : 0,
+          top:    this.props.direction === "column" ? this.getHandleOffset() : 0,
+          backgroundColor: this.props.showHandles? "rgba(0,128,255,0.25)" : "auto",
+          cursor: this.props.direction === "row" ? "col-resize" : "row-resize",
+          zIndex: 100,
+        }
+      }
+      Object.assign(style.divider, {backgroundColor: this.props.borderColor});
+  
+      // Add custom class if dragging
+      var className = "divider";
+      if (this.state.dragging) {
+        className += " dragging";
+      }
+  
+      return (
+        <div className={className} style={style.divider} onMouseDown={this.onMouseDown}>
+          <div style={style.handle}></div>
+        </div>
+      );
+    }
+  }
+  
+  Divider.defaultProps = {
+    dividerWidth: 1,
+    handleBleed: 4,
+  };
+
+export default Divider;

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+class Panel extends React.Component {
+
+    // Find the resizeObject if it has one
+    componentDidMount () {
+      if (this.props.resize === "stretch") {
+        this.refs.resizeObject.addEventListener("load", () => this.onResizeObjectLoad());
+        this.refs.resizeObject.data = "about:blank";
+        this.calculateStretchWidth();
+      }
+    }
+  
+    // Attach resize event listener to resizeObject
+    onResizeObjectLoad = () => {
+      this.refs.resizeObject.contentDocument.defaultView.addEventListener(
+      "resize", () => this.calculateStretchWidth());
+    };
+  
+    // Utility function to wait for next render before executing a function
+    onNextFrame = (callback) => {
+      setTimeout(function () {
+          window.requestAnimationFrame(callback)
+      }, 0)
+    };
+  
+    // Recalculate the stretchy panel if it's container has been resized
+    calculateStretchWidth = () => {
+      if (this.props.onWindowResize !== null) {
+        var rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
+  
+        this.props.onWindowResize(
+          this.props.panelID,
+          {x:rect.width, y:rect.height},
+  
+          // recalcalculate again if the width is below minimum
+          // Kinda hacky, but for large resizes like fullscreen/Restore
+          // it can't solve it in one pass.
+          // function() {this.onNextFrame(this.calculateStretchWidth)}.bind(this)
+        );
+      }
+    };
+  
+    // Render component
+    render () {
+  
+      var style = {
+        resizeObject: {
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          zIndex: -1,
+          opacity: 0,
+        }
+      }
+  
+      // only attach resize object if panel is stretchy.  Others dont need it
+      const resizeObject = this.props.resize === "stretch" ? <object style={style.resizeObject} ref="resizeObject" type="text/html"></object> : null;
+  
+      return (
+        <div className="panelWrapper" style={this.props.style}>
+          {resizeObject}
+          {this.props.children}
+        </div>
+      )
+    }
+}
+  
+export default Panel;


### PR DESCRIPTION
This PR implements the following features:

* [#20](https://github.com/DanFessler/react-panelgroup/issues/20) Add basic support for `maxWidth` for Panels. This can be specified just like "minWidth", and defaults to 0 (ie: disabled)
* Add a second argument to the `onUpdate` callback, allowing more seamless integration with external state libraries

Additionally, code has been refactored to break apart Divider, Panel, and Panel Group into standalone components.

#### Remaining TODO:

* Add tests covering the `maxWidth` and `isComplete` behaviors.