### PR TITLE
Add touch listeners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8197 @@
+{
+  "name": "react-panelgroup",
+  "version": "1.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "collections": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
+      "integrity": "sha1-HyMCay7zb5J+7MkB6ZxfDUj6M04=",
+      "dev": true,
+      "requires": {
+        "weak-map": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+      "dev": true,
+      "requires": {
+        "graceful-readlink": ">= 1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "dev": true,
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
+      }
+    },
+    "fsevents": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.14.tgz",
+      "integrity": "sha1-VY6Mw4ZD2O9A/kUVhIbQ0ldY7uQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.29"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.0 || ^1.1.13"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bl": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "readable-stream": "~2.0.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "~2.0.0"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^0.4.1",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.x.x"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "1.0.0-rc4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "async": "^1.5.2",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.10"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
+          }
+        },
+        "gauge": {
+          "version": "2.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-color": "^0.1.7",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-property": "^1.0.0"
+          }
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-color": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.13.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "jsonpointer": "2.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonpointer": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.2",
+            "verror": "1.3.6"
+          }
+        },
+        "mime-db": {
+          "version": "1.23.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.23.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "mkdirp": "~0.5.0",
+            "nopt": "~3.0.1",
+            "npmlog": "~3.1.2",
+            "rc": "~1.1.0",
+            "request": "2.x",
+            "rimraf": "~2.5.0",
+            "semver": "~5.2.0",
+            "tar": "~2.2.0",
+            "tar-pack": "~3.1.0"
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "npmlog": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.6.0",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "qs": {
+          "version": "6.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~1.0.4"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "request": {
+          "version": "2.73.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc4",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.2.0",
+            "tunnel-agent": "~0.4.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "semver": {
+          "version": "5.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "sshpk": {
+          "version": "1.8.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.13.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "bundled": true,
+          "dev": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
+          }
+        },
+        "tar-pack": {
+          "version": "3.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "fstream": "~1.0.10",
+            "fstream-ignore": "~1.0.5",
+            "once": "~1.3.3",
+            "readable-stream": "~2.1.4",
+            "rimraf": "~2.5.1",
+            "tar": "~2.2.1",
+            "uid-number": "~0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.13.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "gh-pages": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-0.11.0.tgz",
+      "integrity": "sha1-kzE8bcv8dNQmvIminr/2QgrMPBs=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "commander": "2.9.0",
+        "globby": "^4.0.0",
+        "graceful-fs": "4.1.2",
+        "q": "1.4.1",
+        "q-io": "1.13.2",
+        "wrench": "1.5.8"
+      }
+    },
+    "glob": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "dev": true,
+      "requires": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globby": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+      "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^6.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
+      "integrity": "sha1-/iI5t1dJcuZ+QfgIgj+b+kqZHjc=",
+      "dev": true
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
+      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "mimeparse": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
+      "integrity": "sha1-2vsCdSNw/SJgk64xUsJxrwGsJUo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "nwb": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/nwb/-/nwb-0.12.2.tgz",
+      "integrity": "sha1-bDfv3+OLLYZcep8HXUtL9VSpLac=",
+      "dev": true,
+      "requires": {
+        "argv-set-env": "1.0.1",
+        "autoprefixer": "6.4.0",
+        "babel-cli": "6.11.4",
+        "babel-core": "6.13.2",
+        "babel-loader": "6.2.4",
+        "babel-plugin-add-module-exports": "0.2.1",
+        "babel-plugin-istanbul": "2.0.0",
+        "babel-plugin-lodash": "3.2.8",
+        "babel-plugin-react-transform": "2.0.2",
+        "babel-plugin-transform-decorators-legacy": "1.3.4",
+        "babel-plugin-transform-react-remove-prop-types": "0.2.9",
+        "babel-plugin-transform-runtime": "6.12.0",
+        "babel-polyfill": "6.13.0",
+        "babel-preset-es2015": "6.13.2",
+        "babel-preset-es2016": "6.11.3",
+        "babel-preset-react": "6.11.1",
+        "babel-preset-stage-0": "6.5.0",
+        "babel-preset-stage-1": "6.13.0",
+        "babel-preset-stage-2": "6.13.0",
+        "babel-preset-stage-3": "6.11.0",
+        "babel-runtime": "6.11.6",
+        "case-sensitive-paths-webpack-plugin": "1.1.3",
+        "chalk": "1.1.3",
+        "connect-history-api-fallback": "1.3.0",
+        "copy-template-dir": "1.3.0",
+        "copy-webpack-plugin": "3.0.1",
+        "css-loader": "0.23.1",
+        "debug": "2.2.0",
+        "detect-port": "1.0.0",
+        "diff": "2.2.3",
+        "eventsource-polyfill": "0.9.6",
+        "expect": "1.20.2",
+        "express": "4.14.0",
+        "extract-text-webpack-plugin": "1.0.1",
+        "figures": "1.7.0",
+        "file-loader": "0.9.0",
+        "filesize": "3.3.0",
+        "fs-extra": "0.30.0",
+        "fsevents": "1.0.14",
+        "glob": "7.0.5",
+        "gzip-size": "3.0.0",
+        "html-webpack-plugin": "2.22.0",
+        "inquirer": "1.1.2",
+        "json-loader": "0.5.4",
+        "karma": "1.2.0",
+        "karma-chrome-launcher": "1.0.1",
+        "karma-coverage": "1.1.1",
+        "karma-mocha": "1.1.1",
+        "karma-mocha-reporter": "2.1.0",
+        "karma-phantomjs-launcher": "1.0.1",
+        "karma-sourcemap-loader": "0.3.7",
+        "karma-webpack": "1.8.0",
+        "minimist": "1.2.0",
+        "mocha": "3.0.2",
+        "npm-install-webpack-plugin": "4.0.4",
+        "object-assign": "4.1.0",
+        "ora": "0.3.0",
+        "phantomjs-prebuilt": "2.1.12",
+        "postcss-loader": "0.10.0",
+        "promise": "7.1.1",
+        "qs": "6.2.1",
+        "react-transform-catch-errors": "1.0.2",
+        "react-transform-hmr": "1.0.4",
+        "redbox-noreact": "1.1.0",
+        "resolve": "1.1.7",
+        "rimraf": "2.5.4",
+        "style-loader": "0.13.1",
+        "temp": "0.8.3",
+        "url-loader": "0.5.7",
+        "webpack": "1.13.1",
+        "webpack-dev-middleware": "1.6.1",
+        "webpack-fail-plugin": "1.0.5",
+        "webpack-hot-middleware": "2.12.2",
+        "webpack-md5-hash": "0.0.5",
+        "webpack-merge": "0.14.1",
+        "whatwg-fetch": "1.0.0"
+      },
+      "dependencies": {
+        "Base64": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "abbrev": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true
+        },
+        "accepts": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.11",
+            "negotiator": "0.6.1"
+          }
+        },
+        "acorn": {
+          "version": "3.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "after": {
+          "version": "0.8.1",
+          "bundled": true,
+          "dev": true
+        },
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "alphanum-sort": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "amdefine": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-html": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "anymatch": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "micromatch": "^2.1.5"
+          }
+        },
+        "argparse": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "argv-set-env": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "array-find-index": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "array-slice": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "arraybuffer.slice": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "asap": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "assert": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "util": "0.10.3"
+          }
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "autoprefixer": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "browserslist": "~1.3.5",
+            "caniuse-db": "^1.0.30000515",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.1.1",
+            "postcss-value-parser": "^3.2.3"
+          }
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws4": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-cli": {
+          "version": "6.11.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-core": "^6.11.4",
+            "babel-polyfill": "^6.9.0",
+            "babel-register": "^6.9.0",
+            "babel-runtime": "^6.9.0",
+            "bin-version-check": "^2.1.0",
+            "chalk": "1.1.1",
+            "chokidar": "^1.0.0",
+            "commander": "^2.8.1",
+            "convert-source-map": "^1.1.0",
+            "fs-readdir-recursive": "^0.1.0",
+            "glob": "^5.0.5",
+            "lodash": "^4.2.0",
+            "log-symbols": "^1.0.2",
+            "output-file-sync": "^1.1.0",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "request": "^2.65.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0",
+            "v8flags": "^2.0.10"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^2.1.0",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "glob": {
+              "version": "5.0.15",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^2.0.0"
+          }
+        },
+        "babel-core": {
+          "version": "6.13.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.8.0",
+            "babel-generator": "^6.11.4",
+            "babel-helpers": "^6.8.0",
+            "babel-messages": "^6.8.0",
+            "babel-register": "^6.9.0",
+            "babel-runtime": "^6.9.1",
+            "babel-template": "^6.9.0",
+            "babel-traverse": "^6.13.0",
+            "babel-types": "^6.13.0",
+            "babylon": "^6.7.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^2.1.1",
+            "json5": "^0.4.0",
+            "lodash": "^4.2.0",
+            "minimatch": "^3.0.2",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "private": "^0.1.6",
+            "shebang-regex": "^1.0.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0"
+          }
+        },
+        "babel-generator": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.16.0",
+            "detect-indent": "^3.0.1",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.2.0",
+            "source-map": "^0.5.0"
+          }
+        },
+        "babel-helper-bindify-decorators": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.15.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.15.0"
+          }
+        },
+        "babel-helper-builder-react-jsx": {
+          "version": "6.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0",
+            "esutils": "^2.0.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "6.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-function-name": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-explode-class": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-bindify-decorators": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-get-function-arity": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0",
+            "babel-traverse": "^6.8.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-function-name": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.16.0",
+            "babel-types": "^6.16.0"
+          }
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-optimise-call-expression": "^6.8.0",
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.16.0",
+            "babel-types": "^6.16.0"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.16.0"
+          }
+        },
+        "babel-loader": {
+          "version": "6.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loader-utils": "^0.2.11",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-add-module-exports": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^1.1.2",
+            "istanbul-lib-instrument": "^1.1.0-alpha.4",
+            "test-exclude": "^2.1.1"
+          }
+        },
+        "babel-plugin-lodash": {
+          "version": "3.2.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5",
+            "lodash": "^4.15.0"
+          }
+        },
+        "babel-plugin-react-transform": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash": "^4.6.1"
+          }
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-class-constructor-call": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-class-properties": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-decorators": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-do-expressions": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-export-extensions": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-flow": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-function-bind": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "^6.16.0",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-class-constructor-call": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-class-constructor-call": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-class-properties": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-function-name": "^6.8.0",
+            "babel-plugin-syntax-class-properties": "^6.8.0",
+            "babel-runtime": "^6.9.1"
+          }
+        },
+        "babel-plugin-transform-decorators": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-define-map": "^6.8.0",
+            "babel-helper-explode-class": "^6.8.0",
+            "babel-plugin-syntax-decorators": "^6.13.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0",
+            "babel-types": "^6.13.0"
+          }
+        },
+        "babel-plugin-transform-decorators-legacy": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-decorators": "^6.1.18",
+            "babel-runtime": "^6.2.0",
+            "babel-template": "^6.3.0"
+          }
+        },
+        "babel-plugin-transform-do-expressions": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-do-expressions": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.15.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-template": "^6.15.0",
+            "babel-traverse": "^6.15.0",
+            "babel-types": "^6.15.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.14.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-define-map": "^6.9.0",
+            "babel-helper-function-name": "^6.8.0",
+            "babel-helper-optimise-call-expression": "^6.8.0",
+            "babel-helper-replace-supers": "^6.14.0",
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-template": "^6.14.0",
+            "babel-traverse": "^6.14.0",
+            "babel-types": "^6.14.0"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-define-map": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-function-name": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.16.0",
+            "babel-types": "^6.16.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.14.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.8.0",
+            "babel-runtime": "^6.11.6",
+            "babel-template": "^6.14.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-template": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-replace-supers": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-call-delegate": "^6.8.0",
+            "babel-helper-get-function-arity": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.16.0",
+            "babel-types": "^6.16.0"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-regex": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.11.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-regex": "^6.8.0",
+            "babel-runtime": "^6.0.0",
+            "regexpu-core": "^2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.8.0",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-export-extensions": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-export-extensions": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-flow-strip-types": {
+          "version": "6.14.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-flow": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-function-bind": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-function-bind": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-object-rest-spread": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-react-display-name": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx": {
+          "version": "6.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-helper-builder-react-jsx": "^6.8.0",
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.0.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-self": {
+          "version": "6.11.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-source": {
+          "version": "6.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-react-remove-prop-types": {
+          "version": "0.2.9",
+          "bundled": true,
+          "dev": true
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.16.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.16.0",
+            "private": "~0.1.5"
+          }
+        },
+        "babel-plugin-transform-runtime": {
+          "version": "6.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.0"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.11.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.0.0",
+            "babel-types": "^6.8.0"
+          }
+        },
+        "babel-polyfill": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.1",
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.9.5"
+          }
+        },
+        "babel-preset-es2015": {
+          "version": "6.13.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "^6.3.13",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.3.13",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.3.13",
+            "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
+            "babel-plugin-transform-es2015-classes": "^6.9.0",
+            "babel-plugin-transform-es2015-computed-properties": "^6.3.13",
+            "babel-plugin-transform-es2015-destructuring": "^6.9.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.6.0",
+            "babel-plugin-transform-es2015-for-of": "^6.6.0",
+            "babel-plugin-transform-es2015-function-name": "^6.9.0",
+            "babel-plugin-transform-es2015-literals": "^6.3.13",
+            "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.6.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.12.0",
+            "babel-plugin-transform-es2015-modules-umd": "^6.12.0",
+            "babel-plugin-transform-es2015-object-super": "^6.3.13",
+            "babel-plugin-transform-es2015-parameters": "^6.9.0",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.3.13",
+            "babel-plugin-transform-es2015-spread": "^6.3.13",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.3.13",
+            "babel-plugin-transform-es2015-template-literals": "^6.6.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.6.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.3.13",
+            "babel-plugin-transform-regenerator": "^6.9.0"
+          }
+        },
+        "babel-preset-es2016": {
+          "version": "6.11.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-transform-exponentiation-operator": "^6.3.13"
+          }
+        },
+        "babel-preset-react": {
+          "version": "6.11.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-flow": "^6.3.13",
+            "babel-plugin-syntax-jsx": "^6.3.13",
+            "babel-plugin-transform-flow-strip-types": "^6.3.13",
+            "babel-plugin-transform-react-display-name": "^6.3.13",
+            "babel-plugin-transform-react-jsx": "^6.3.13",
+            "babel-plugin-transform-react-jsx-self": "^6.11.0",
+            "babel-plugin-transform-react-jsx-source": "^6.3.13"
+          }
+        },
+        "babel-preset-stage-0": {
+          "version": "6.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-transform-do-expressions": "^6.3.13",
+            "babel-plugin-transform-function-bind": "^6.3.13",
+            "babel-preset-stage-1": "^6.3.13"
+          }
+        },
+        "babel-preset-stage-1": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-transform-class-constructor-call": "^6.3.13",
+            "babel-plugin-transform-export-extensions": "^6.3.13",
+            "babel-preset-stage-2": "^6.13.0"
+          }
+        },
+        "babel-preset-stage-2": {
+          "version": "6.13.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-transform-class-properties": "^6.3.13",
+            "babel-plugin-transform-decorators": "^6.13.0",
+            "babel-plugin-transform-object-rest-spread": "^6.3.13",
+            "babel-preset-stage-3": "^6.11.0"
+          }
+        },
+        "babel-preset-stage-3": {
+          "version": "6.11.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-plugin-syntax-trailing-function-commas": "^6.3.13",
+            "babel-plugin-transform-async-to-generator": "^6.3.13",
+            "babel-plugin-transform-exponentiation-operator": "^6.3.13"
+          }
+        },
+        "babel-register": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-core": "^6.16.0",
+            "babel-runtime": "^6.11.6",
+            "core-js": "^2.4.0",
+            "home-or-tmp": "^1.0.0",
+            "lodash": "^4.2.0",
+            "mkdirp": "^0.5.1",
+            "path-exists": "^1.0.0",
+            "source-map-support": "^0.4.2"
+          },
+          "dependencies": {
+            "babel-core": {
+              "version": "6.16.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "babel-code-frame": "^6.16.0",
+                "babel-generator": "^6.16.0",
+                "babel-helpers": "^6.16.0",
+                "babel-messages": "^6.8.0",
+                "babel-register": "^6.16.0",
+                "babel-runtime": "^6.9.1",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.16.0",
+                "babel-types": "^6.16.0",
+                "babylon": "^6.11.0",
+                "convert-source-map": "^1.1.0",
+                "debug": "^2.1.1",
+                "json5": "^0.4.0",
+                "lodash": "^4.2.0",
+                "minimatch": "^3.0.2",
+                "path-exists": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "private": "^0.1.6",
+                "shebang-regex": "^1.0.0",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.0"
+              }
+            }
+          }
+        },
+        "babel-runtime": {
+          "version": "6.11.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.9.5"
+          }
+        },
+        "babel-template": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.0",
+            "babel-traverse": "^6.16.0",
+            "babel-types": "^6.16.0",
+            "babylon": "^6.11.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "^6.16.0",
+            "babel-messages": "^6.8.0",
+            "babel-runtime": "^6.9.0",
+            "babel-types": "^6.16.0",
+            "babylon": "^6.11.0",
+            "debug": "^2.2.0",
+            "globals": "^8.3.0",
+            "invariant": "^2.2.0",
+            "lodash": "^4.2.0"
+          }
+        },
+        "babel-types": {
+          "version": "6.16.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.9.1",
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^1.0.1"
+          }
+        },
+        "babylon": {
+          "version": "6.11.2",
+          "bundled": true,
+          "dev": true
+        },
+        "backo2": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "base64-arraybuffer": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "base64-js": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "base64id": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "benchmark": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "better-assert": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "callsite": "1.0.0"
+          }
+        },
+        "big.js": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "bin-version": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-versions": "^1.0.0"
+          }
+        },
+        "bin-version-check": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bin-version": "^1.0.0",
+            "minimist": "^1.1.0",
+            "semver": "^4.0.3",
+            "semver-truncate": "^1.0.0"
+          }
+        },
+        "binary-extensions": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "bl": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.0.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "blob": {
+          "version": "0.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "bundled": true,
+          "dev": true
+        },
+        "body-parser": {
+          "version": "1.15.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bytes": "2.4.0",
+            "content-type": "~1.0.2",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "http-errors": "~1.5.0",
+            "iconv-lite": "0.4.13",
+            "on-finished": "~2.3.0",
+            "qs": "6.2.0",
+            "raw-body": "~2.1.7",
+            "type-is": "~1.6.13"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "6.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "boolbase": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^0.4.1",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "browser-stdout": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pako": "~0.2.0"
+          }
+        },
+        "browserslist": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "caniuse-db": "^1.0.30000525"
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "bytes": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "callsite": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "camel-case": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
+          }
+        },
+        "caniuse-db": {
+          "version": "1.0.30000541",
+          "bundled": true,
+          "dev": true
+        },
+        "case-sensitive-paths-webpack-plugin": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "bundled": true,
+          "dev": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "change-case": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "constant-case": "^2.0.0",
+            "dot-case": "^2.1.0",
+            "header-case": "^1.0.0",
+            "is-lower-case": "^1.1.0",
+            "is-upper-case": "^1.1.0",
+            "lower-case": "^1.1.1",
+            "lower-case-first": "^1.0.0",
+            "no-case": "^2.2.0",
+            "param-case": "^2.1.0",
+            "pascal-case": "^2.0.0",
+            "path-case": "^2.1.0",
+            "sentence-case": "^2.1.0",
+            "snake-case": "^2.1.0",
+            "swap-case": "^1.1.0",
+            "title-case": "^2.1.0",
+            "upper-case": "^1.1.1",
+            "upper-case-first": "^1.1.0"
+          }
+        },
+        "charenc": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "chokidar": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          }
+        },
+        "clap": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3"
+          }
+        },
+        "clean-css": {
+          "version": "3.4.20",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commander": "2.8.x",
+            "source-map": "0.4.x"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.8.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "cli-spinners": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cli-width": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "clone": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "coa": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "q": "^1.1.2"
+          }
+        },
+        "code-point-at": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "color": {
+          "version": "0.11.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "clone": "^1.0.2",
+            "color-convert": "^1.3.0",
+            "color-string": "^0.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "color-name": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "color-string": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-name": "^1.0.0"
+          }
+        },
+        "colormin": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color": "^0.11.0",
+            "css-color-names": "0.0.4",
+            "has": "^1.0.1"
+          }
+        },
+        "colors": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "combine-lists": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash": "^4.5.0"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "component-bind": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "component-emitter": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "component-inherit": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "connect": {
+          "version": "3.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "finalhandler": "0.5.0",
+            "parseurl": "~1.3.1",
+            "utils-merge": "1.0.0"
+          }
+        },
+        "connect-history-api-fallback": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "date-now": "^0.1.4"
+          }
+        },
+        "constant-case": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "snake-case": "^2.1.0",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "content-disposition": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "copy-template-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "graceful-fs": "^4.1.3",
+            "maxstache": "^1.0.0",
+            "maxstache-stream": "^1.0.0",
+            "mkdirp": "^0.5.1",
+            "noop2": "^2.0.0",
+            "pump": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "run-parallel": "^1.1.4"
+          }
+        },
+        "copy-webpack-plugin": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^2.10.2",
+            "fs-extra": "^0.26.4",
+            "glob": "^6.0.4",
+            "lodash": "^4.3.0",
+            "minimatch": "^3.0.0",
+            "node-dir": "^0.1.10"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "0.26.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
+              }
+            },
+            "glob": {
+              "version": "6.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "core-js": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pseudomap": "^1.0.1",
+                "yallist": "^2.0.0"
+              }
+            }
+          }
+        },
+        "crypt": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.x.x"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.2.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pbkdf2-compat": "2.0.1",
+            "ripemd160": "0.2.0",
+            "sha.js": "2.2.6"
+          }
+        },
+        "css-color-names": {
+          "version": "0.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "css-loader": {
+          "version": "0.23.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.5.1",
+            "cssnano": ">=2.6.1 <4",
+            "loader-utils": "~0.2.2",
+            "lodash.camelcase": "^3.0.1",
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.6",
+            "postcss-modules-extract-imports": "^1.0.0",
+            "postcss-modules-local-by-default": "^1.0.1",
+            "postcss-modules-scope": "^1.0.0",
+            "postcss-modules-values": "^1.1.0",
+            "source-list-map": "^0.1.4"
+          }
+        },
+        "css-select": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.5.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cssesc": "^0.1.0",
+            "fastparse": "^1.1.1"
+          }
+        },
+        "css-what": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cssesc": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cssnano": {
+          "version": "3.7.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "autoprefixer": "^6.3.1",
+            "decamelize": "^1.1.2",
+            "defined": "^1.0.0",
+            "has": "^1.0.1",
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.14",
+            "postcss-calc": "^5.2.0",
+            "postcss-colormin": "^2.1.8",
+            "postcss-convert-values": "^2.3.4",
+            "postcss-discard-comments": "^2.0.4",
+            "postcss-discard-duplicates": "^2.0.1",
+            "postcss-discard-empty": "^2.0.1",
+            "postcss-discard-overridden": "^0.1.1",
+            "postcss-discard-unused": "^2.2.1",
+            "postcss-filter-plugins": "^2.0.0",
+            "postcss-merge-idents": "^2.1.5",
+            "postcss-merge-longhand": "^2.0.1",
+            "postcss-merge-rules": "^2.0.3",
+            "postcss-minify-font-values": "^1.0.2",
+            "postcss-minify-gradients": "^1.0.1",
+            "postcss-minify-params": "^1.0.4",
+            "postcss-minify-selectors": "^2.0.4",
+            "postcss-normalize-charset": "^1.1.0",
+            "postcss-normalize-url": "^3.0.7",
+            "postcss-ordered-values": "^2.1.0",
+            "postcss-reduce-idents": "^2.2.2",
+            "postcss-reduce-initial": "^1.0.0",
+            "postcss-reduce-transforms": "^1.0.3",
+            "postcss-svgo": "^2.1.1",
+            "postcss-unique-selectors": "^2.0.2",
+            "postcss-value-parser": "^3.2.3",
+            "postcss-zindex": "^2.0.1"
+          }
+        },
+        "csso": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "clap": "^1.0.9",
+            "source-map": "^0.5.3"
+          }
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "array-find-index": "^1.0.1"
+          }
+        },
+        "custom-event": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "dashdash": {
+          "version": "1.14.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "date-now": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "dateformat": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreach": "^2.0.5",
+            "object-keys": "^1.0.8"
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "depd": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1",
+            "minimist": "^1.1.0",
+            "repeating": "^1.1.0"
+          }
+        },
+        "detect-port": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commander": "~2.8.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.8.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            }
+          }
+        },
+        "di": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "diff": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "dom-converter": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "utila": "~0.3"
+          },
+          "dependencies": {
+            "utila": {
+              "version": "0.3.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "dom-serialize": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "custom-event": "~1.0.0",
+            "ent": "~2.2.0",
+            "extend": "^3.0.0",
+            "void-elements": "^2.0.0"
+          }
+        },
+        "dom-serializer": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "domelementtype": "~1.1.1",
+            "entities": "~1.1.1"
+          },
+          "dependencies": {
+            "domelementtype": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "dom-walk": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true
+        },
+        "domelementtype": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "domhandler": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "dot-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "duplexer": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "end-of-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "~1.3.0"
+          },
+          "dependencies": {
+            "once": {
+              "version": "1.3.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            }
+          }
+        },
+        "engine.io": {
+          "version": "1.6.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "accepts": "1.1.4",
+            "base64id": "0.1.0",
+            "debug": "2.2.0",
+            "engine.io-parser": "1.2.4",
+            "ws": "1.0.1"
+          },
+          "dependencies": {
+            "accepts": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mime-types": "~2.0.4",
+                "negotiator": "0.4.9"
+              }
+            },
+            "mime-db": {
+              "version": "1.12.0",
+              "bundled": true,
+              "dev": true
+            },
+            "mime-types": {
+              "version": "2.0.14",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "mime-db": "~1.12.0"
+              }
+            },
+            "negotiator": {
+              "version": "0.4.9",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "engine.io-client": {
+          "version": "1.6.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.1.2",
+            "component-inherit": "0.0.3",
+            "debug": "2.2.0",
+            "engine.io-parser": "1.2.4",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parsejson": "0.0.1",
+            "parseqs": "0.0.2",
+            "parseuri": "0.0.4",
+            "ws": "1.0.1",
+            "xmlhttprequest-ssl": "1.5.1",
+            "yeast": "0.1.2"
+          }
+        },
+        "engine.io-parser": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "after": "0.8.1",
+            "arraybuffer.slice": "0.0.6",
+            "base64-arraybuffer": "0.1.2",
+            "blob": "0.0.4",
+            "has-binary": "0.1.6",
+            "utf8": "2.1.0"
+          },
+          "dependencies": {
+            "has-binary": {
+              "version": "0.1.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ent": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "errno": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prr": "~0.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "error-stack-parser": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "stackframe": "^0.3.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.0",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.3"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.1",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.1"
+          }
+        },
+        "es6-promise": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "esprima": "^2.7.1",
+            "estraverse": "^1.9.1",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.2.0"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "bundled": true,
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "bundled": true,
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "etag": {
+          "version": "1.7.0",
+          "bundled": true,
+          "dev": true
+        },
+        "eventemitter3": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "events": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "eventsource-polyfill": {
+          "version": "0.9.6",
+          "bundled": true,
+          "dev": true
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "expand-braces": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "array-slice": "^0.2.3",
+            "array-unique": "^0.2.1",
+            "braces": "^0.1.2"
+          },
+          "dependencies": {
+            "braces": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "expand-range": "^0.1.0"
+              }
+            },
+            "expand-range": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-number": "^0.1.1",
+                "repeat-string": "^0.2.2"
+              }
+            },
+            "is-number": {
+              "version": "0.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "repeat-string": {
+              "version": "0.2.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fill-range": "^2.1.0"
+          }
+        },
+        "expect": {
+          "version": "1.20.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-properties": "~1.1.2",
+            "has": "^1.0.1",
+            "is-equal": "^1.5.1",
+            "is-regex": "^1.0.3",
+            "object-inspect": "^1.1.0",
+            "object-keys": "^1.0.9",
+            "tmatch": "^2.0.1"
+          }
+        },
+        "express": {
+          "version": "4.14.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.3",
+            "array-flatten": "1.1.1",
+            "content-disposition": "0.5.1",
+            "content-type": "~1.0.2",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
+            "finalhandler": "0.5.0",
+            "fresh": "0.3.0",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.1",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~1.1.2",
+            "qs": "6.2.0",
+            "range-parser": "~1.2.0",
+            "send": "0.14.1",
+            "serve-static": "~1.11.1",
+            "type-is": "~1.6.13",
+            "utils-merge": "1.0.0",
+            "vary": "~1.1.0"
+          },
+          "dependencies": {
+            "qs": {
+              "version": "6.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "external-editor": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extend": "^3.0.0",
+            "spawn-sync": "^1.0.15",
+            "temp": "^0.8.3"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "extract-text-webpack-plugin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^1.5.0",
+            "loader-utils": "^0.2.3",
+            "webpack-sources": "^0.1.0"
+          }
+        },
+        "extract-zip": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "concat-stream": "1.5.0",
+            "debug": "0.7.4",
+            "mkdirp": "0.5.0",
+            "yauzl": "2.4.1"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "~2.0.0",
+                "typedarray": "~0.0.5"
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "bundled": true,
+              "dev": true
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "readable-stream": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "fastparse": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fd-slicer": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "file-loader": {
+          "version": "0.9.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loader-utils": "~0.2.5"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "filesize": {
+          "version": "3.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "finalhandler": {
+          "version": "0.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "statuses": "~1.3.0",
+            "unpipe": "~1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "find-versions": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "array-uniq": "^1.0.0",
+            "get-stdin": "^4.0.1",
+            "meow": "^3.5.0",
+            "semver-regex": "^1.0.0"
+          }
+        },
+        "flatten": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "for-in": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "for-own": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-in": "^0.1.5"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.11"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fs-access": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "null-check": "^1.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "0.30.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "function-bind": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-property": "^1.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "global": {
+          "version": "4.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
+          }
+        },
+        "globals": {
+          "version": "8.18.0",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.9",
+          "bundled": true,
+          "dev": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "growl": {
+          "version": "1.9.2",
+          "bundled": true,
+          "dev": true
+        },
+        "gzip-size": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.1"
+          }
+        },
+        "handlebars": {
+          "version": "4.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.0.2"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-binary": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "has-cors": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hasha": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-stream": "^1.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
+          }
+        },
+        "he": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "header-case": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.1.3"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "home-or-tmp": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "^1.0.1",
+            "user-home": "^1.1.1"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "html-comment-regex": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "html-entities": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "html-minifier": {
+          "version": "2.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "change-case": "3.0.x",
+            "clean-css": "3.4.x",
+            "commander": "2.9.x",
+            "he": "1.1.x",
+            "ncname": "1.0.x",
+            "relateurl": "0.2.x",
+            "uglify-js": "2.6.x"
+          }
+        },
+        "html-webpack-plugin": {
+          "version": "2.22.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.4.1",
+            "html-minifier": "^2.1.6",
+            "loader-utils": "^0.2.15",
+            "lodash": "^4.13.1",
+            "pretty-error": "^2.0.0",
+            "toposort": "^1.0.0"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "3.4.6",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "htmlparser2": {
+          "version": "3.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.1",
+            "domutils": "1.1",
+            "readable-stream": "1.0"
+          },
+          "dependencies": {
+            "domutils": {
+              "version": "1.1.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "domelementtype": "1"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "Base64": "~0.2.0",
+            "inherits": "~2.0.1"
+          }
+        },
+        "http-errors": {
+          "version": "1.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1",
+            "setprototypeof": "1.0.1",
+            "statuses": ">= 1.3.0 < 2"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "1.15.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "eventemitter3": "1.x.x",
+            "requires-port": "1.x.x"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "bundled": true,
+          "dev": true
+        },
+        "icss-replace-symbols": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ieee754": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "indent-string": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          },
+          "dependencies": {
+            "repeating": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-finite": "^1.0.0"
+              }
+            }
+          }
+        },
+        "indexes-of": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "inquirer": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "external-editor": "^1.0.1",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.6",
+            "pinkie-promise": "^2.0.0",
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "bundled": true,
+          "dev": true
+        },
+        "invariant": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "ipaddr.js": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-absolute-url": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrow-function": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.0.4"
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-boolean-object": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-dotfile": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "is-equal": {
+          "version": "1.5.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has": "^1.0.1",
+            "is-arrow-function": "^2.0.3",
+            "is-boolean-object": "^1.0.0",
+            "is-callable": "^1.1.3",
+            "is-date-object": "^1.0.1",
+            "is-generator-function": "^1.0.3",
+            "is-number-object": "^1.0.3",
+            "is-regex": "^1.0.3",
+            "is-string": "^1.0.4",
+            "is-symbol": "^1.0.1",
+            "object.entries": "^1.0.3"
+          }
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-finite": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-generator-function": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-lower-case": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lower-case": "^1.1.0"
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.14.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "jsonpointer": "2.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-number-object": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-string": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "is-svg": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "html-comment-regex": "^1.1.0"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-upper-case": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "upper-case": "^1.1.0"
+          }
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isbinaryfile": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul": {
+          "version": "0.4.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.x",
+            "async": "1.x",
+            "escodegen": "1.8.x",
+            "esprima": "2.7.x",
+            "glob": "^5.0.15",
+            "handlebars": "^4.0.1",
+            "js-yaml": "3.x",
+            "mkdirp": "0.5.x",
+            "nopt": "3.x",
+            "once": "1.x",
+            "resolve": "1.1.x",
+            "supports-color": "^3.1.0",
+            "which": "^1.1.1",
+            "wordwrap": "^1.0.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "babel-generator": "^6.11.3",
+            "babel-template": "^6.9.0",
+            "babel-traverse": "^6.9.0",
+            "babel-types": "^6.10.2",
+            "babylon": "^6.8.1",
+            "istanbul-lib-coverage": "^1.0.0"
+          }
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
+        },
+        "js-base64": {
+          "version": "2.1.9",
+          "bundled": true,
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "json-loader": {
+          "version": "0.5.4",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json3": {
+          "version": "3.2.6",
+          "bundled": true,
+          "dev": true
+        },
+        "json5": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "jsonpointer": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "jsprim": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          }
+        },
+        "karma": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.3.0",
+            "body-parser": "^1.12.4",
+            "chokidar": "^1.4.1",
+            "colors": "^1.1.0",
+            "combine-lists": "^1.0.0",
+            "connect": "^3.3.5",
+            "core-js": "^2.2.0",
+            "di": "^0.0.1",
+            "dom-serialize": "^2.2.0",
+            "expand-braces": "^0.1.1",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "http-proxy": "^1.13.0",
+            "isbinaryfile": "^3.0.0",
+            "lodash": "^3.8.0",
+            "log4js": "^0.6.31",
+            "mime": "^1.3.4",
+            "minimatch": "^3.0.0",
+            "optimist": "^0.6.1",
+            "qjobs": "^1.1.4",
+            "rimraf": "^2.3.3",
+            "socket.io": "1.4.7",
+            "source-map": "^0.5.3",
+            "tmp": "0.0.28",
+            "useragent": "^2.1.9"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "3.4.6",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "karma-chrome-launcher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs-access": "^1.0.0",
+            "which": "^1.2.1"
+          }
+        },
+        "karma-coverage": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dateformat": "^1.0.6",
+            "istanbul": "^0.4.0",
+            "lodash": "^3.8.0",
+            "minimatch": "^3.0.0",
+            "source-map": "^0.5.1"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "3.10.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "karma-mocha": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "karma-mocha-reporter": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        },
+        "karma-phantomjs-launcher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash": "^4.0.1",
+            "phantomjs-prebuilt": "^2.1.7"
+          }
+        },
+        "karma-sourcemap-loader": {
+          "version": "0.3.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2"
+          }
+        },
+        "karma-webpack": {
+          "version": "1.8.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "~0.9.0",
+            "loader-utils": "^0.2.5",
+            "lodash": "^3.8.0",
+            "source-map": "^0.1.41",
+            "webpack-dev-middleware": "^1.0.11"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "bundled": true,
+              "dev": true
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "kew": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.0.2"
+          }
+        },
+        "klaw": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.16",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          },
+          "dependencies": {
+            "json5": {
+              "version": "0.5.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.16.2",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._arraycopy": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._arrayeach": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._baseassign": {
+          "version": "3.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash._basecallback": {
+          "version": "3.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._baseisequal": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.pairs": "^3.0.0"
+          }
+        },
+        "lodash._basecopy": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._basecreate": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._baseeach": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash._basefind": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._basefindindex": {
+          "version": "3.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._basefor": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._baseisequal": {
+          "version": "3.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash.isarray": "^3.0.0",
+            "lodash.istypedarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._createassigner": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0",
+            "lodash.restparam": "^3.0.0"
+          }
+        },
+        "lodash._createcompounder": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash.deburr": "^3.0.0",
+            "lodash.words": "^3.0.0"
+          }
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._isiterateecall": {
+          "version": "3.0.9",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._root": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.camelcase": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._createcompounder": "^3.0.0"
+          }
+        },
+        "lodash.create": {
+          "version": "3.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._baseassign": "^3.0.0",
+            "lodash._basecreate": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
+          }
+        },
+        "lodash.deburr": {
+          "version": "3.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._root": "^3.0.0"
+          }
+        },
+        "lodash.find": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._basecallback": "^3.0.0",
+            "lodash._baseeach": "^3.0.0",
+            "lodash._basefind": "^3.0.0",
+            "lodash._basefindindex": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash.indexof": {
+          "version": "4.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.isarguments": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.isequal": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.isplainobject": {
+          "version": "3.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._basefor": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.keysin": "^3.0.0"
+          }
+        },
+        "lodash.istypedarray": {
+          "version": "3.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
+        },
+        "lodash.keysin": {
+          "version": "3.0.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "^3.0.0",
+            "lodash._arrayeach": "^3.0.0",
+            "lodash._createassigner": "^3.0.0",
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.isplainobject": "^3.0.0",
+            "lodash.istypedarray": "^3.0.0",
+            "lodash.keys": "^3.0.0",
+            "lodash.keysin": "^3.0.0",
+            "lodash.toplainobject": "^3.0.0"
+          }
+        },
+        "lodash.pairs": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash.keys": "^3.0.0"
+          }
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.toplainobject": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "^3.0.0",
+            "lodash.keysin": "^3.0.0"
+          }
+        },
+        "lodash.words": {
+          "version": "3.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._root": "^3.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "log4js": {
+          "version": "0.6.38",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "readable-stream": "~1.0.2",
+            "semver": "~4.3.3"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^1.0.1"
+          },
+          "dependencies": {
+            "js-tokens": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "lower-case": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "lower-case-first": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lower-case": "^1.1.2"
+          }
+        },
+        "lru-cache": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "macaddress": {
+          "version": "0.2.8",
+          "bundled": true,
+          "dev": true
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "math-expression-evaluator": {
+          "version": "1.2.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash.indexof": "^4.0.5"
+          }
+        },
+        "maxstache": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "maxstache-stream": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "maxstache": "^1.0.0",
+            "pump": "^1.0.0",
+            "split2": "^1.0.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "md5": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "charenc": "~0.0.1",
+            "crypt": "~0.0.1",
+            "is-buffer": "~1.1.1"
+          }
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "memory-fs": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "meow": {
+          "version": "3.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
+          }
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "mime": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.24.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.24.0"
+          }
+        },
+        "min-document": {
+          "version": "2.19.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dom-walk": "^0.1.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mocha": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "browser-stdout": "1.3.0",
+            "commander": "2.9.0",
+            "debug": "2.2.0",
+            "diff": "1.4.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.0.5",
+            "growl": "1.9.2",
+            "json3": "3.3.2",
+            "lodash.create": "3.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "3.1.2"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true
+            },
+            "json3": {
+              "version": "3.3.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "ncname": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "xml-char-classes": "^1.0.0"
+          }
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "no-case": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lower-case": "^1.1.1"
+          }
+        },
+        "node-dir": {
+          "version": "0.1.16",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.2"
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert": "^1.1.1",
+            "browserify-zlib": "~0.1.4",
+            "buffer": "^4.9.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "0.0.1",
+            "crypto-browserify": "~3.2.6",
+            "domain-browser": "^1.1.1",
+            "events": "^1.0.0",
+            "http-browserify": "^1.3.2",
+            "https-browserify": "0.0.0",
+            "os-browserify": "~0.1.2",
+            "path-browserify": "0.0.0",
+            "process": "^0.11.0",
+            "punycode": "^1.2.4",
+            "querystring-es3": "~0.2.0",
+            "readable-stream": "^1.1.13",
+            "stream-browserify": "^1.0.0",
+            "string_decoder": "~0.10.25",
+            "timers-browserify": "^1.0.1",
+            "tty-browserify": "0.0.0",
+            "url": "~0.10.1",
+            "util": "~0.10.3",
+            "vm-browserify": "0.0.4"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "process": {
+              "version": "0.11.9",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "bundled": true,
+          "dev": true
+        },
+        "noop2": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-range": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-url": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
+          }
+        },
+        "npm-install-webpack-plugin": {
+          "version": "4.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4.0.0",
+            "memory-fs": "^0.3.0"
+          }
+        },
+        "nth-check": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boolbase": "~1.0.0"
+          }
+        },
+        "null-check": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "num2fraction": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "number-is-nan": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "object-component": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "object-inspect": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true
+        },
+        "object.entries": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.1",
+            "es-abstract": "^1.3.2",
+            "function-bind": "^1.0.2",
+            "has": "^1.0.1"
+          }
+        },
+        "object.omit": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "for-own": "^0.1.3",
+            "is-extendable": "^0.1.1"
+          }
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "options": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "ora": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.1",
+            "cli-cursor": "^1.0.2",
+            "cli-spinners": "^0.2.0",
+            "log-symbols": "^1.0.2"
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-shim": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "output-file-sync": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.4",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "pako": {
+          "version": "0.2.9",
+          "bundled": true,
+          "dev": true
+        },
+        "param-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "parsejson": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
+        },
+        "parseqs": {
+          "version": "0.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
+        },
+        "parseuri": {
+          "version": "0.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "better-assert": "~1.0.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pascal-case": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "upper-case-first": "^1.1.0"
+          }
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pbkdf2-compat": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pend": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "phantomjs-prebuilt": {
+          "version": "2.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-promise": "~3.2.1",
+            "extract-zip": "~1.5.0",
+            "fs-extra": "~0.30.0",
+            "hasha": "~2.2.0",
+            "kew": "~0.7.0",
+            "progress": "~1.1.8",
+            "request": "~2.74.0",
+            "request-progress": "~2.0.1",
+            "which": "~1.2.10"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lodash": "^4.8.0"
+              }
+            },
+            "form-data": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "async": "^2.0.1",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.11"
+              }
+            },
+            "request": {
+              "version": "2.74.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "bl": "~1.1.2",
+                "caseless": "~0.11.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~1.0.0-rc4",
+                "har-validator": "~2.0.6",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "node-uuid": "~1.4.7",
+                "oauth-sign": "~0.8.1",
+                "qs": "~6.2.0",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "~0.4.1"
+              }
+            }
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "postcss": {
+          "version": "5.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.1.2"
+          }
+        },
+        "postcss-calc": {
+          "version": "5.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.2",
+            "postcss-message-helpers": "^2.0.0",
+            "reduce-css-calc": "^1.2.6"
+          }
+        },
+        "postcss-colormin": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "colormin": "^1.0.5",
+            "postcss": "^5.0.13",
+            "postcss-value-parser": "^3.2.3"
+          }
+        },
+        "postcss-convert-values": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.11",
+            "postcss-value-parser": "^3.1.2"
+          }
+        },
+        "postcss-discard-comments": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.14"
+          }
+        },
+        "postcss-discard-duplicates": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4"
+          }
+        },
+        "postcss-discard-empty": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.14"
+          }
+        },
+        "postcss-discard-overridden": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.16"
+          }
+        },
+        "postcss-discard-unused": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "flatten": "1.0.2",
+            "postcss": "^5.0.14",
+            "uniqs": "^2.0.0"
+          }
+        },
+        "postcss-filter-plugins": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "uniqid": "^3.0.0"
+          }
+        },
+        "postcss-loader": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loader-utils": "^0.2.15",
+            "postcss": "^5.1.2"
+          }
+        },
+        "postcss-merge-idents": {
+          "version": "2.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has": "^1.0.1",
+            "postcss": "^5.0.10",
+            "postcss-value-parser": "^3.1.1"
+          }
+        },
+        "postcss-merge-longhand": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4"
+          }
+        },
+        "postcss-merge-rules": {
+          "version": "2.0.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "vendors": "^1.0.0"
+          }
+        },
+        "postcss-message-helpers": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "postcss-minify-font-values": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
+          }
+        },
+        "postcss-minify-gradients": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.12",
+            "postcss-value-parser": "^3.1.3"
+          }
+        },
+        "postcss-minify-params": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.2",
+            "postcss-value-parser": "^3.0.2",
+            "uniqs": "^2.0.0"
+          }
+        },
+        "postcss-minify-selectors": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "alphanum-sort": "^1.0.2",
+            "postcss": "^5.0.14",
+            "postcss-selector-parser": "^2.0.0"
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4"
+          }
+        },
+        "postcss-modules-local-by-default": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.6.0",
+            "postcss": "^5.0.4"
+          },
+          "dependencies": {
+            "css-selector-tokenizer": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
+              }
+            },
+            "regexpu-core": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+              }
+            }
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "css-selector-tokenizer": "^0.6.0",
+            "postcss": "^5.0.4"
+          },
+          "dependencies": {
+            "css-selector-tokenizer": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
+              }
+            },
+            "regexpu-core": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
+              }
+            }
+          }
+        },
+        "postcss-modules-values": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "icss-replace-symbols": "^1.0.2",
+            "postcss": "^5.0.14"
+          }
+        },
+        "postcss-normalize-charset": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.5"
+          }
+        },
+        "postcss-normalize-url": {
+          "version": "3.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-absolute-url": "^2.0.0",
+            "normalize-url": "^1.4.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3"
+          }
+        },
+        "postcss-ordered-values": {
+          "version": "2.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.1"
+          }
+        },
+        "postcss-reduce-idents": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
+          }
+        },
+        "postcss-reduce-initial": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4"
+          }
+        },
+        "postcss-reduce-transforms": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.8",
+            "postcss-value-parser": "^3.0.1"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "flatten": "^1.0.2",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "postcss-svgo": {
+          "version": "2.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-svg": "^2.0.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3",
+            "svgo": "^0.7.0"
+          }
+        },
+        "postcss-unique-selectors": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "postcss-zindex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pretty-error": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "renderkid": "~2.0.0",
+            "utila": "~0.4"
+          }
+        },
+        "private": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "process": {
+          "version": "0.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true
+        },
+        "promise": {
+          "version": "7.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        },
+        "proxy-addr": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "forwarded": "~0.1.0",
+            "ipaddr.js": "1.1.1"
+          }
+        },
+        "prr": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "pump": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "q": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "qjobs": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "qs": {
+          "version": "6.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "query-string": {
+          "version": "4.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "randomatic": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-number": "^2.0.2",
+            "kind-of": "^3.0.2"
+          }
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bytes": "2.4.0",
+            "iconv-lite": "0.4.13",
+            "unpipe": "1.0.0"
+          }
+        },
+        "react-deep-force-update": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "react-proxy": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash": "^4.6.1",
+            "react-deep-force-update": "^1.0.0"
+          }
+        },
+        "react-transform-catch-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "react-transform-hmr": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "global": "^4.3.0",
+            "react-proxy": "^1.1.7"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
+          }
+        },
+        "redbox-noreact": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-stack-parser": "1.3.6"
+          }
+        },
+        "redent": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
+          }
+        },
+        "reduce-css-calc": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^0.4.2",
+            "math-expression-evaluator": "^1.2.14",
+            "reduce-function-call": "^1.0.1"
+          }
+        },
+        "reduce-function-call": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "~0.1.0"
+          },
+          "dependencies": {
+            "balanced-match": {
+              "version": "0.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "regenerate": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.9.5",
+          "bundled": true,
+          "dev": true
+        },
+        "regex-cache": {
+          "version": "0.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-equal-shallow": "^0.1.3",
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "relateurl": {
+          "version": "0.2.7",
+          "bundled": true,
+          "dev": true
+        },
+        "renderkid": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "css-select": "^1.1.0",
+            "dom-converter": "~0.1",
+            "htmlparser2": "~3.3.0",
+            "strip-ansi": "^3.0.0",
+            "utila": "~0.3"
+          },
+          "dependencies": {
+            "utila": {
+              "version": "0.3.3",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "repeat-string": {
+          "version": "1.5.4",
+          "bundled": true,
+          "dev": true
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "request": {
+          "version": "2.75.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.1.2",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.0.0",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.2.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1"
+          }
+        },
+        "request-progress": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "throttleit": "^1.0.0"
+          }
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "requires-port": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "ripemd160": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "run-async": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-promise": "^2.1.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "rx": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "sax": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "4.3.6",
+          "bundled": true,
+          "dev": true
+        },
+        "semver-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "semver-truncate": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "^5.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "send": {
+          "version": "0.14.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
+            "fresh": "0.3.0",
+            "http-errors": "~1.5.0",
+            "mime": "1.3.4",
+            "ms": "0.7.1",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.0"
+          }
+        },
+        "sentence-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case-first": "^1.1.2"
+          }
+        },
+        "serve-static": {
+          "version": "1.11.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.1",
+            "send": "0.14.1"
+          }
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "sha.js": {
+          "version": "2.2.6",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "snake-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0"
+          }
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.x.x"
+          }
+        },
+        "socket.io": {
+          "version": "1.4.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "2.2.0",
+            "engine.io": "1.6.10",
+            "has-binary": "0.1.7",
+            "socket.io-adapter": "0.4.0",
+            "socket.io-client": "1.4.6",
+            "socket.io-parser": "2.2.6"
+          }
+        },
+        "socket.io-adapter": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "2.2.0",
+            "socket.io-parser": "2.2.2"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "socket.io-parser": {
+              "version": "2.2.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "benchmark": "1.0.0",
+                "component-emitter": "1.1.2",
+                "debug": "0.7.4",
+                "isarray": "0.0.1",
+                "json3": "3.2.6"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "socket.io-client": {
+          "version": "1.4.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.0",
+            "debug": "2.2.0",
+            "engine.io-client": "1.6.9",
+            "has-binary": "0.1.7",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseuri": "0.0.4",
+            "socket.io-parser": "2.2.6",
+            "to-array": "0.1.4"
+          },
+          "dependencies": {
+            "component-emitter": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "socket.io-parser": {
+          "version": "2.2.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "benchmark": "1.0.0",
+            "component-emitter": "1.1.2",
+            "debug": "2.2.0",
+            "isarray": "0.0.1",
+            "json3": "3.3.2"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "json3": {
+              "version": "3.3.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "sort-keys": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "source-list-map": {
+          "version": "0.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "0.1.32"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "spawn-sync": {
+          "version": "1.0.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.4.7",
+            "os-shim": "^0.1.2"
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "^1.0.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "split2": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "through2": "~2.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "sshpk": {
+          "version": "1.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "stackframe": {
+          "version": "0.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "~2.0.1",
+            "readable-stream": "^1.0.27-1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "bundled": true,
+          "dev": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-indent": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "get-stdin": "^4.0.1"
+          }
+        },
+        "style-loader": {
+          "version": "0.13.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loader-utils": "^0.2.7"
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        },
+        "svgo": {
+          "version": "0.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "coa": "~1.0.1",
+            "colors": "~1.1.2",
+            "csso": "~2.2.1",
+            "js-yaml": "~3.6.1",
+            "mkdirp": "~0.5.1",
+            "sax": "~1.2.1",
+            "whet.extend": "~0.9.9"
+          }
+        },
+        "swap-case": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lower-case": "^1.1.1",
+            "upper-case": "^1.1.1"
+          }
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "bundled": true,
+          "dev": true
+        },
+        "temp": {
+          "version": "0.8.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "test-exclude": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "lodash.assign": "^4.1.0",
+            "micromatch": "^2.3.11",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "throttleit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.0.0",
+            "xtend": "~4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "process": "~0.11.0"
+          },
+          "dependencies": {
+            "process": {
+              "version": "0.11.9",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "title-case": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^2.2.0",
+            "upper-case": "^1.0.3"
+          }
+        },
+        "tmatch": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tmp": {
+          "version": "0.0.28",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.1"
+          }
+        },
+        "to-array": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "toposort": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "trim-newlines": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "bundled": true,
+          "dev": true
+        },
+        "tweetnacl": {
+          "version": "0.14.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-is": {
+          "version": "1.6.13",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.11"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "2.6.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ultron": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "uniqid": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "macaddress": "^0.2.8"
+          }
+        },
+        "uniqs": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "upper-case": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "upper-case-first": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "upper-case": "^1.1.1"
+          }
+        },
+        "url": {
+          "version": "0.10.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "url-loader": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loader-utils": "0.2.x",
+            "mime": "1.2.x"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "1.2.11",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "useragent": {
+          "version": "2.1.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.2.x"
+          }
+        },
+        "utf8": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "utila": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "v8flags": {
+          "version": "2.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "user-home": "^1.1.1"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
+          }
+        },
+        "vary": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "vendors": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "indexof": "0.0.1"
+          }
+        },
+        "void-elements": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^0.9.0",
+            "chokidar": "^1.0.0",
+            "graceful-fs": "^4.1.2"
+          },
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "webpack": {
+          "version": "1.13.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.0",
+            "async": "^1.3.0",
+            "clone": "^1.0.2",
+            "enhanced-resolve": "~0.9.0",
+            "interpret": "^0.6.4",
+            "loader-utils": "^0.2.11",
+            "memory-fs": "~0.3.0",
+            "mkdirp": "~0.5.0",
+            "node-libs-browser": ">= 0.4.0 <=0.6.0",
+            "optimist": "~0.6.0",
+            "supports-color": "^3.1.0",
+            "tapable": "~0.1.8",
+            "uglify-js": "~2.6.0",
+            "watchpack": "^0.2.1",
+            "webpack-core": "~0.6.0"
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-list-map": "~0.1.0",
+            "source-map": "~0.4.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "memory-fs": "~0.3.0",
+            "mime": "^1.3.4",
+            "range-parser": "^1.0.3"
+          }
+        },
+        "webpack-fail-plugin": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "webpack-hot-middleware": {
+          "version": "2.12.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-html": "0.0.5",
+            "html-entities": "^1.2.0",
+            "querystring": "^0.2.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "webpack-md5-hash": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5": "^2.0.0"
+          }
+        },
+        "webpack-merge": {
+          "version": "0.14.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash.find": "^3.2.1",
+            "lodash.isequal": "^4.2.0",
+            "lodash.isplainobject": "^3.2.0",
+            "lodash.merge": "^3.3.2"
+          }
+        },
+        "webpack-sources": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-list-map": "~0.1.0",
+            "source-map": "~0.5.3"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "whet.extend": {
+          "version": "0.9.9",
+          "bundled": true,
+          "dev": true
+        },
+        "which": {
+          "version": "1.2.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^1.1.1"
+          }
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ws": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
+        },
+        "xml-char-classes": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "xmlhttprequest-ssl": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "yauzl": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fd-slicer": "~1.0.1"
+          }
+        },
+        "yeast": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "q": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+      "dev": true
+    },
+    "q-io": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.13.2.tgz",
+      "integrity": "sha1-7qEw1IHdteGqG8WmaFX3OR0G8AM=",
+      "dev": true,
+      "requires": {
+        "collections": "^0.2.0",
+        "mime": "^1.2.11",
+        "mimeparse": "^0.1.4",
+        "q": "^1.0.1",
+        "qs": "^1.2.1",
+        "url2": "^0.0.0"
+      }
+    },
+    "qs": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+      "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g=",
+      "dev": true
+    },
+    "react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-dom": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.3.2.tgz",
+      "integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+      "dev": true
+    },
+    "url2": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz",
+      "integrity": "sha1-Tqq9HVw6yQ1iq0SFyZhCKGWgSxo=",
+      "dev": true
+    },
+    "weak-map": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz",
+      "integrity": "sha1-tm5Wqd8L0lp2u/G1FNsSkIBhSjc=",
+      "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "wrench": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz",
+      "integrity": "sha1-ejHJf3hpJG12xc8vXJd6HEyOWrU=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-panelgroup",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "react-panelgroup React component",
   "main": "lib/PanelGroup.js",
   "jsnext:main": "es/PanelGroup.js",

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -452,28 +452,39 @@ class Divider extends React.Component {
     };
   }
 
+  componentDidMount () {
+    this.root.addEventListener('touchstart', this.onMouseDown, { passive: false })
+  }
+
   // Add/remove event listeners based on drag state
   componentDidUpdate (props, state) {
     if (this.state.dragging && !state.dragging) {
       document.addEventListener('mousemove', this.onMouseMove)
+      document.addEventListener('touchmove', this.onMouseMove, { passive: false })
       document.addEventListener('mouseup', this.onMouseUp)
+      document.addEventListener('touchend', this.onMouseUp, { passive: false })
     } else if (!this.state.dragging && state.dragging) {
       document.removeEventListener('mousemove', this.onMouseMove)
+      document.removeEventListener('touchmove', this.onMouseMove)
       document.removeEventListener('mouseup', this.onMouseUp)
+      document.removeEventListener('touchend', this.onMouseUp)
     }
   }
 
   // Start drag state and set initial position
   onMouseDown = (e) => {
 
-    // only left mouse button
-    if (e.button !== 0) return
+    // only left mouse button on mouse click
+    if (e.type === 'mousedown' && e.button !== 0) return
+
+    const pageX = e.type === 'touchstart' ? parseInt(e.touches[0].pageX, 10) : e.pageX
+    const pageY = e.type === 'touchstart' ? parseInt(e.touches[0].pageY, 10) : e.pageY
 
     this.setState({
       dragging: true,
       initPos: {
-        x: e.pageX,
-        y: e.pageY
+        x: pageX,
+        y: pageY
       },
     })
 
@@ -492,9 +503,12 @@ class Divider extends React.Component {
   onMouseMove = (e) => {
     if (!this.state.dragging) return
 
+    const pageX = e.type === 'touchmove' ? parseInt(e.touches[0].pageX, 10) : e.pageX
+    const pageY = e.type === 'touchmove' ? parseInt(e.touches[0].pageY, 10) : e.pageY
+
     let initDelta = {
-      x: e.pageX - this.state.initPos.x,
-      y: e.pageY - this.state.initPos.y
+      x: pageX - this.state.initPos.x,
+      y: pageY - this.state.initPos.y
     }
 
     let flowMask = {
@@ -519,8 +533,8 @@ class Divider extends React.Component {
       this.setState({
         initPos: {
           // if we moved more than expected, add the difference to the Position
-          x: e.pageX + (expectedDelta? 0 : resultDelta * flowMask.x),
-          y: e.pageY + (expectedDelta? 0 : resultDelta * flowMask.y)
+          x: pageX + (expectedDelta? 0 : resultDelta * flowMask.x),
+          y: pageY + (expectedDelta? 0 : resultDelta * flowMask.y)
         },
       })
     }
@@ -542,6 +556,10 @@ class Divider extends React.Component {
   getHandleOffset = () => {
     return (this.props.dividerWidth/2) - (this.getHandleWidth()/2);
   };
+
+  createRef = (ref) => {
+    this.root = ref
+  }
 
   // Render component
   render () {
@@ -576,7 +594,7 @@ class Divider extends React.Component {
     }
 
     return (
-      <div className={className} style={style.divider} onMouseDown={this.onMouseDown}>
+      <div className={className} ref={this.createRef} style={style.divider} onMouseDown={this.onMouseDown}>
         <div style={style.handle}></div>
       </div>
     );


### PR DESCRIPTION
Adds `touchstart`/`touchmove`/`touchend` listeners. Only listens for the first touch (in the case of multi-touch). Uses `passive: false` to prevent the page from scrolling when a `touchmove` occurs. Closes #16.