### PR TITLE
Error log message correction

### DIFF
--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -222,7 +222,7 @@ class PanelGroup extends React.Component {
         ? boundingRect.height
         : boundingRect.width) -
       this.props.spacing * (this.props.children.length - 1);
-    if (masterSize != boundingSize) {
+    if (Math.abs(boundingSize, masterSize) <= 0.01) {
       console.log(panels[0], panels[1]);
       console.log("ERROR! SIZES DON'T MATCH!: ", masterSize, boundingSize);
       // 2) Rectify the situation by adding all the unacounted for space to the first panel

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -222,7 +222,7 @@ class PanelGroup extends React.Component {
         ? boundingRect.height
         : boundingRect.width) -
       this.props.spacing * (this.props.children.length - 1);
-    if (Math.abs(boundingSize, masterSize) <= 0.01) {
+    if (Math.abs(boundingSize - masterSize) <= 0.01) {
       console.log(panels[0], panels[1]);
       console.log("ERROR! SIZES DON'T MATCH!: ", masterSize, boundingSize);
       // 2) Rectify the situation by adding all the unacounted for space to the first panel


### PR DESCRIPTION
In some specific cases (mostly random) the Panel Group component may output a lot of disturbing log messages in the console like this one:

```
{size: 118.4519271850586, minSize: 100, resize: "stretch", snap: Array(0)} {size: 342, minSize: 50, resize: "dynamic", snap: Array(0)}
PanelGroup.js:91 ERROR! SIZES DON'T MATCH!:  460.4519271850586 460.4519348144531
```

This is due to this specific line the source code:

```
if (masterSize != boundingSize) {
```

This is an equality test between two values that are sometimes floats instead of integers. When they are floats they may have some variation due to rounding problems. (Good old advice: never compare equality between floats without some tolerance).

This pull request fixes that problem.